### PR TITLE
Provide an explicit default value for `sudoers:lookup`

### DIFF
--- a/sudoers/map.jinja
+++ b/sudoers/map.jinja
@@ -13,4 +13,4 @@
                 'config-path': '/usr/local/etc',
                 'exec-prefix': '/usr/local/sbin',
                 'group': 'wheel'},
-}, merge=salt['pillar.get']('sudoers:lookup')) %}
+}, merge=salt['pillar.get']('sudoers:lookup', None)) %}


### PR DESCRIPTION
Setting `pillar_raise_on_missing` triggered an error here. This fixes it.